### PR TITLE
feat: add web UI and standardize postgres/mqtt configuration

### DIFF
--- a/charts/private-assistant/Chart.yaml
+++ b/charts/private-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: private-assistant
-description: A Helm chart for Kubernetes
+description: A Helm chart for Private Assistant ecosystem with optional Web UI
 type: application
-version: 0.8.1
+version: 0.9.0
 appVersion: "0.3.6"
 dependencies:
   - name: valkey

--- a/charts/private-assistant/templates/ground_station_deployment.yaml
+++ b/charts/private-assistant/templates/ground_station_deployment.yaml
@@ -11,6 +11,7 @@ kind: Deployment
           env:
             - name: PRIVATE_ASSISTANT_API_CONFIG_PATH
               value: /app/config.yaml
+            {{- include "private-assistant.mqtt.env" (dict "component" "groundStation" "componentConfig" nil "context" .) | nindent 12 }}
             {{- toYaml .Values.globalEnv | nindent 12 }}
           ports:
             - name: http

--- a/charts/private-assistant/templates/intent_engine_deployment.yaml
+++ b/charts/private-assistant/templates/intent_engine_deployment.yaml
@@ -11,6 +11,8 @@ kind: Deployment
           env:
             - name: PRIVATE_ASSISTANT_CONFIG_PATH
               value: /app/config.yaml
+            {{- include "private-assistant.postgres.env" (dict "component" "intentEngine" "componentConfig" nil "context" .) | nindent 12 }}
+            {{- include "private-assistant.mqtt.env" (dict "component" "intentEngine" "componentConfig" nil "context" .) | nindent 12 }}
             {{- with $.Values.intentEngine.globalEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/private-assistant/templates/skill_deployments.yaml
+++ b/charts/private-assistant/templates/skill_deployments.yaml
@@ -39,6 +39,8 @@ spec:
           env:
             - name: PRIVATE_ASSISTANT_CONFIG_PATH
               value: /config/
+            {{- include "private-assistant.postgres.env" (dict "component" .name "componentConfig" nil "context" $) | nindent 12 }}
+            {{- include "private-assistant.mqtt.env" (dict "component" .name "componentConfig" nil "context" $) | nindent 12 }}
             {{- with .env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/private-assistant/templates/webui_backend_deployment.yaml
+++ b/charts/private-assistant/templates/webui_backend_deployment.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.webUiBackend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+{{ include "private-assistant.deployment.metadata" (dict "component" "webui-backend" "replicas" .Values.webUiBackend.replicas "hasComponentLabel" true "context" .) }}
+{{ include "private-assistant.deployment.podMetadata" (dict "component" "webui-backend" "imagePullSecret" .Values.webUiBackend.image.pullSecret "hasComponentLabel" true "context" .) }}
+      containers:
+        - name: webui-backend
+          image: "{{ .Values.webUiBackend.image.repository }}:{{ .Values.webUiBackend.image.tag }}"
+          imagePullPolicy: {{ .Values.webUiBackend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            {{- include "private-assistant.postgres.env" (dict "component" "webUiBackend" "componentConfig" .Values.webUiBackend.config.postgres "context" .) | nindent 12 }}
+            {{- include "private-assistant.mqtt.env" (dict "component" "webUiBackend" "componentConfig" .Values.webUiBackend.config.mqtt "context" .) | nindent 12 }}
+
+            # MinIO Configuration
+            - name: MINIO_ENDPOINT
+              value: {{ .Values.webUiBackend.config.minio.endpoint | quote }}
+            - name: MINIO_BUCKET_NAME
+              value: {{ .Values.webUiBackend.config.minio.bucketName | quote }}
+            - name: MINIO_SECURE
+              value: {{ .Values.webUiBackend.config.minio.secure | quote }}
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.webUiBackend.existingSecret }}{{ .Values.webUiBackend.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
+                  key: minio-access-key
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.webUiBackend.existingSecret }}{{ .Values.webUiBackend.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
+                  key: minio-secret-key
+
+            # Application Configuration
+            - name: ENVIRONMENT
+              value: {{ .Values.webUiBackend.config.app.environment | quote }}
+            - name: PROJECT_NAME
+              value: {{ .Values.webUiBackend.config.app.projectName | quote }}
+            - name: BACKEND_CORS_ORIGINS
+              value: {{ .Values.webUiBackend.config.app.backendCorsOrigins | quote }}
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.webUiBackend.existingSecret }}{{ .Values.webUiBackend.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
+                  key: secret-key
+            - name: FIRST_SUPERUSER
+              value: {{ .Values.webUiBackend.config.app.firstSuperuser | quote }}
+            - name: FIRST_SUPERUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.webUiBackend.existingSecret }}{{ .Values.webUiBackend.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
+                  key: first-superuser-password
+            - name: FRONTEND_HOST
+              value: {{ .Values.webUiBackend.config.app.frontendHost | quote }}
+            - name: DISABLE_OAUTH
+              value: {{ .Values.webUiBackend.config.app.disableOauth | quote }}
+            {{- if .Values.webUiBackend.config.app.oauthIssuer }}
+            - name: OAUTH_ISSUER
+              value: {{ .Values.webUiBackend.config.app.oauthIssuer | quote }}
+            {{- end }}
+            {{- if .Values.webUiBackend.config.app.oauthClientId }}
+            - name: OAUTH_CLIENT_ID
+              value: {{ .Values.webUiBackend.config.app.oauthClientId | quote }}
+            {{- end }}
+            {{- with .Values.globalEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- include "private-assistant.deployment.httpProbes" . | nindent 10 }}
+          resources:
+            {{- toYaml .Values.webUiBackend.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.webUiBackend.securityContext | nindent 12 }}
+{{- end }}

--- a/charts/private-assistant/templates/webui_backend_ingress.yaml
+++ b/charts/private-assistant/templates/webui_backend_ingress.yaml
@@ -1,0 +1,3 @@
+{{- if and .Values.webUiBackend.enabled .Values.webUiBackend.ingress.enabled -}}
+{{- include "private-assistant.ingress" (dict "component" "webui-backend" "serviceName" "webui-backend" "nameSuffix" "" "config" .Values.webUiBackend.ingress "context" .) }}
+{{- end }}

--- a/charts/private-assistant/templates/webui_backend_secret.yaml
+++ b/charts/private-assistant/templates/webui_backend_secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.webUiBackend.enabled (not .Values.webUiBackend.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "private-assistant.fullname" . }}-webui-backend
+  labels:
+    {{- include "private-assistant.labels" . | nindent 4 }}
+type: Opaque
+data:
+  postgres-password: {{ .Values.webUiBackend.config.postgres.password | default "changethis" | b64enc | quote }}
+  minio-access-key: {{ .Values.webUiBackend.config.minio.accessKey | default "minioadmin" | b64enc | quote }}
+  minio-secret-key: {{ .Values.webUiBackend.config.minio.secretKey | default "minioadmin" | b64enc | quote }}
+  secret-key: {{ .Values.webUiBackend.config.app.secretKey | default "changethis" | b64enc | quote }}
+  first-superuser-password: {{ .Values.webUiBackend.config.app.firstSuperuserPassword | default "changethis" | b64enc | quote }}
+  mqtt-password: {{ .Values.webUiBackend.config.mqtt.password | default "" | b64enc | quote }}
+{{- end }}

--- a/charts/private-assistant/templates/webui_backend_service.yaml
+++ b/charts/private-assistant/templates/webui_backend_service.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.webUiBackend.enabled }}
+{{- include "private-assistant.service" (dict "component" "webui-backend" "serviceType" .Values.webUiBackend.service.type "context" .) }}
+{{- end }}

--- a/charts/private-assistant/templates/webui_frontend_configmap.yaml
+++ b/charts/private-assistant/templates/webui_frontend_configmap.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.webUiFrontend.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "private-assistant.fullname" . }}-webui-frontend-nginx
+  labels:
+    {{- include "private-assistant.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # Gzip compression
+        gzip on;
+        gzip_vary on;
+        gzip_min_length 1024;
+        gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+
+        # API proxy to backend service
+        location /api/v1/ {
+            proxy_pass {{ include "private-assistant.webui.backendUrl" . }}/api/v1/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Port $server_port;
+
+            # WebSocket support (if needed)
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            # Timeouts
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+
+        # Frontend static files
+        location / {
+            try_files $uri $uri/ /index.html;
+
+            # Cache static assets
+            location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+                expires 1y;
+                add_header Cache-Control "public, immutable";
+            }
+        }
+
+        # Health check endpoint
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+    }
+{{- end }}

--- a/charts/private-assistant/templates/webui_frontend_deployment.yaml
+++ b/charts/private-assistant/templates/webui_frontend_deployment.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.webUiFrontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+{{ include "private-assistant.deployment.metadata" (dict "component" "webui-frontend" "replicas" .Values.webUiFrontend.replicas "hasComponentLabel" true "context" .) }}
+{{ include "private-assistant.deployment.podMetadata" (dict "component" "webui-frontend" "imagePullSecret" .Values.webUiFrontend.image.pullSecret "hasComponentLabel" true "context" .) }}
+      containers:
+        - name: webui-frontend
+          image: "{{ .Values.webUiFrontend.image.repository }}:{{ .Values.webUiFrontend.image.tag }}"
+          imagePullPolicy: {{ .Values.webUiFrontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              port: http
+              path: /health
+            initialDelaySeconds: 5
+            failureThreshold: 3
+            periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              port: http
+              path: /health
+            initialDelaySeconds: 5
+            failureThreshold: 3
+            periodSeconds: 15
+          startupProbe:
+            httpGet:
+              port: http
+              path: /health
+            failureThreshold: 30
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.webUiFrontend.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.webUiFrontend.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "private-assistant.fullname" . }}-webui-frontend-nginx
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/private-assistant/templates/webui_frontend_ingress.yaml
+++ b/charts/private-assistant/templates/webui_frontend_ingress.yaml
@@ -1,0 +1,3 @@
+{{- if and .Values.webUiFrontend.enabled .Values.webUiFrontend.ingress.enabled -}}
+{{- include "private-assistant.ingress" (dict "component" "webui-frontend" "serviceName" "webui-frontend" "nameSuffix" "" "config" .Values.webUiFrontend.ingress "context" .) }}
+{{- end }}

--- a/charts/private-assistant/templates/webui_frontend_service.yaml
+++ b/charts/private-assistant/templates/webui_frontend_service.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.webUiFrontend.enabled }}
+{{- include "private-assistant.service" (dict "component" "webui-frontend" "serviceType" .Values.webUiFrontend.service.type "context" .) }}
+{{- end }}

--- a/charts/private-assistant/values.yaml
+++ b/charts/private-assistant/values.yaml
@@ -9,13 +9,39 @@ globalEnv:
   - name: TZ
     value: Europe/Berlin
 
+# -- Global PostgreSQL Configuration
+# Shared across all components (intentEngine, skills, webUiBackend)
+# This eliminates duplication when using the same PostgreSQL instance
+postgres:
+  # -- Use an existing secret for PostgreSQL credentials (e.g., from CloudNativePG)
+  existingSecret:
+    # -- Enable to use existing secret instead of direct values
+    enabled: false
+    # -- Name of the existing secret (e.g., "private-assistant-postgres-app" from CNPG)
+    name: ""
+    # -- Keys in the secret for PostgreSQL connection details
+    keys:
+      username: username
+      password: password
+      host: host
+      port: port
+      dbname: dbname
+
+  # -- Direct PostgreSQL connection values (used when existingSecret.enabled is false)
+  # These values are used as fallback if no existing secret is configured
+  server: "postgresql.default.svc.cluster.local"
+  port: 5432
+  db: "private_assistant"
+  user: "postgres"
+  password: "changethis"
+
 # -- TTS (Text-to-Speech) Engine Configuration
 # The TTS engine provides speech synthesis capabilities and uses Valkey (Redis) for caching
 ttsEngine:
   # Container image configuration
   image:
     repository: ghcr.io/stkr22/tts-batch-api-py
-    tag: "4.0.1"
+    tag: "latest"
     pullPolicy: IfNotPresent
     # -- Optional: Name of image pull secret for private registries
     pullSecret: ""
@@ -77,7 +103,7 @@ groundStation:
   # Container image configuration
   image:
     repository: ghcr.io/stkr22/private-assistant-ground-station-py
-    tag: "0.2.1"
+    tag: "latest"
     pullPolicy: IfNotPresent
     # -- Optional: Name of image pull secret for private registries
     pullSecret: ""
@@ -129,7 +155,7 @@ intentEngine:
   # Container image configuration
   image:
     repository: ghcr.io/stkr22/private-assistant-intent-engine-py
-    tag: "0.4.2"
+    tag: "latest"
     pullPolicy: IfNotPresent
     # -- Optional: Name of image pull secret for private registries
     pullSecret: ""
@@ -241,6 +267,10 @@ mosquitto:
   # -- Optional: Provide a custom MQTT server port
   # If empty, uses default port
   servicePort: ""
+  # -- MQTT username for authentication (optional)
+  username: ""
+  # -- MQTT password for authentication (optional)
+  password: "changethis"
 
 # -- Valkey (Redis-compatible) Configuration
 # Valkey is used as a caching layer for the TTS engine
@@ -280,3 +310,143 @@ valkey:
     limits:
       memory: 256Mi
       cpu: 200m
+
+# -- Web UI Backend Configuration
+# FastAPI backend providing REST API for the web interface
+webUiBackend:
+  # -- Enable/disable the Web UI Backend deployment
+  enabled: false
+
+  # Container image configuration
+  image:
+    repository: ghcr.io/stkr22/private-assistant-web-ui-backend
+    tag: "latest"
+    pullPolicy: IfNotPresent
+    pullSecret: ""
+
+  # -- Number of backend replicas
+  replicas: 1
+
+  # -- Resource requests and limits
+  resources: {}
+
+  # Service configuration
+  service:
+    type: ClusterIP
+    port: 8080
+
+  # Ingress configuration for API access
+  ingress:
+    enabled: false
+    className: "traefik"
+    annotations: {}
+    hosts:
+      - host: api.private-assistant.local
+        paths:
+          - path: /api
+            pathType: Prefix
+    tls: []
+
+  # Security context (follows TTS engine pattern - user 1001:1001)
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    runAsUser: 1001
+    runAsGroup: 1001
+    runAsNonRoot: true
+    readOnlyRootFilesystem: false  # FastAPI needs /tmp for uploads, sessions
+    allowPrivilegeEscalation: false
+    privileged: false
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Backend configuration
+  config:
+    # PostgreSQL configuration (optional - uses global postgres config if not specified)
+    # Leave empty to use global postgres configuration defined at the top level
+    postgres: {}
+
+    # MinIO/S3 configuration (external)
+    minio:
+      endpoint: "minio.default.svc.cluster.local:9000"
+      bucketName: "private-assistant"
+      secure: false
+      # Access key and secret key should be set via existingSecret or will use defaults
+
+    # MQTT configuration (optional - uses global mosquitto config if not specified)
+    # Leave empty to use global mosquitto configuration defined at the top level
+    mqtt: {}
+
+    # Application configuration
+    app:
+      environment: "production"
+      projectName: "Private Assistant"
+      backendCorsOrigins: "http://localhost:3000,http://localhost:5173"
+      firstSuperuser: "admin@example.com"
+      disableOauth: true
+      frontendHost: "http://private-assistant.local"
+      oauthIssuer: ""
+      oauthClientId: ""
+      # secretKey should be set via existingSecret or will use default
+      # firstSuperuserPassword should be set via existingSecret or will use default
+
+  # -- Existing secret name containing sensitive values
+  # Expected keys:
+  #   - postgres-password
+  #   - minio-access-key
+  #   - minio-secret-key
+  #   - secret-key
+  #   - first-superuser-password
+  #   - mqtt-password
+  existingSecret: ""
+
+# -- Web UI Frontend Configuration
+# React application served by Nginx
+webUiFrontend:
+  # -- Enable/disable the Web UI Frontend deployment
+  enabled: false
+
+  # Container image configuration
+  image:
+    repository: ghcr.io/stkr22/private-assistant-web-ui-frontend
+    tag: "latest"
+    pullPolicy: IfNotPresent
+    pullSecret: ""
+
+  # -- Number of frontend replicas
+  replicas: 1
+
+  # -- Resource requests and limits
+  resources: {}
+
+  # Service configuration
+  service:
+    type: ClusterIP
+    port: 80
+
+  # Ingress configuration for web access
+  ingress:
+    enabled: false
+    className: "traefik"
+    annotations: {}
+    hosts:
+      - host: private-assistant.local
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+
+  # Security context for Nginx
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    runAsUser: 101  # Nginx default user
+    runAsGroup: 101
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    privileged: false
+    seccompProfile:
+      type: RuntimeDefault


### PR DESCRIPTION
- Add private-assistant-web-ui with backend (FastAPI) and frontend (React/Nginx) deployments
- Add global postgres configuration to eliminate duplication across components
- Standardize MQTT configuration using environment variables across all components
- Bump chart version to 0.9.0
