### PR TITLE
feat: remove legacy MQTT config template

### DIFF
--- a/charts/private-assistant/Chart.yaml
+++ b/charts/private-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: private-assistant
 description: A Helm chart for Private Assistant ecosystem with optional Web UI
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "0.3.6"
 dependencies:
   - name: valkey

--- a/charts/private-assistant/templates/_helpers.tpl
+++ b/charts/private-assistant/templates/_helpers.tpl
@@ -72,18 +72,9 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "private-assistant.config" -}}
-mqtt_server_host: {{ .Values.mosquitto.serviceHost }}
-mqtt_server_port: {{ .Values.mosquitto.servicePort }}
-{{- end -}}
-
 {{- define "private-assistant.groundStationConfig" -}}
 speech_synthesis_api: {{ if .Values.groundStation.ttsServiceHostOverwrite }}{{ .Values.groundStation.ttsServiceHostOverwrite }}{{ else }}http://{{ .Release.Name }}-tts-engine.{{ .Release.Namespace }}.svc{{ if ne .Values.clusterDomain "" }}.{{ .Values.clusterDomain }}/synthesizeSpeech{{ end }}{{ end }}
 speech_synthesis_api_token: {{ if .Values.groundStation.ttsServiceTokenOverwrite }}{{ .Values.groundStation.ttsServiceTokenOverwrite }}{{ else }}{{ .Values.ttsEngine.config.allowedUserToken }}{{ end }}
-{{- end -}}
-
-{{- define "private-assistant.config.base64" -}}
-{{ include "private-assistant.config" . | b64enc }}
 {{- end -}}
 
 {{/*

--- a/charts/private-assistant/templates/ground_station_config.yaml
+++ b/charts/private-assistant/templates/ground_station_config.yaml
@@ -7,6 +7,5 @@ metadata:
     {{- include "private-assistant.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{ include "private-assistant.config" . | nindent 4 }}
     {{ include "private-assistant.groundStationConfig" . | nindent 4 }}
     {{- .Values.groundStation.config | nindent 4 }}

--- a/charts/private-assistant/templates/intent_engine_config.yaml
+++ b/charts/private-assistant/templates/intent_engine_config.yaml
@@ -7,5 +7,4 @@ metadata:
     {{- include "private-assistant.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{ include "private-assistant.config" . | nindent 4 }}
     {{- .Values.intentEngine.config | nindent 4 }}

--- a/charts/private-assistant/templates/skill_base_config.yaml
+++ b/charts/private-assistant/templates/skill_base_config.yaml
@@ -8,7 +8,6 @@ metadata:
     {{- include "private-assistant.labels" $ | nindent 4 }}
 data:
   base_config.yaml: |
-    {{ include "private-assistant.config" $ | nindent 4 }}
     {{ toYaml .config | nindent 4 }}
 ---
 {{- end }}


### PR DESCRIPTION
Remove the unused `private-assistant.config` and `private-assistant.config.base64`
helper templates that are leftovers from the MQTT configuration standardization
refactoring