### PR TITLE
feat: unify web UI configuration structure

### DIFF
--- a/charts/private-assistant/Chart.yaml
+++ b/charts/private-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: private-assistant
 description: A Helm chart for Private Assistant ecosystem with optional Web UI
 type: application
-version: 0.9.1
+version: 0.10.0
 appVersion: "0.3.6"
 dependencies:
   - name: valkey

--- a/charts/private-assistant/templates/webui_backend_deployment.yaml
+++ b/charts/private-assistant/templates/webui_backend_deployment.yaml
@@ -1,75 +1,93 @@
-{{- if .Values.webUiBackend.enabled }}
+{{- if .Values.webUi.enabled }}
 apiVersion: apps/v1
 kind: Deployment
-{{ include "private-assistant.deployment.metadata" (dict "component" "webui-backend" "replicas" .Values.webUiBackend.replicas "hasComponentLabel" true "context" .) }}
-{{ include "private-assistant.deployment.podMetadata" (dict "component" "webui-backend" "imagePullSecret" .Values.webUiBackend.image.pullSecret "hasComponentLabel" true "context" .) }}
+{{ include "private-assistant.deployment.metadata" (dict "component" "webui-backend" "replicas" .Values.webUi.backend.replicas "hasComponentLabel" true "context" .) }}
+{{ include "private-assistant.deployment.podMetadata" (dict "component" "webui-backend" "imagePullSecret" .Values.webUi.backend.image.pullSecret "hasComponentLabel" true "context" .) }}
       containers:
         - name: webui-backend
-          image: "{{ .Values.webUiBackend.image.repository }}:{{ .Values.webUiBackend.image.tag }}"
-          imagePullPolicy: {{ .Values.webUiBackend.image.pullPolicy }}
+          image: "{{ .Values.webUi.backend.image.repository }}:{{ .Values.webUi.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.webUi.backend.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
           env:
-            {{- include "private-assistant.postgres.env" (dict "component" "webUiBackend" "componentConfig" .Values.webUiBackend.config.postgres "context" .) | nindent 12 }}
-            {{- include "private-assistant.mqtt.env" (dict "component" "webUiBackend" "componentConfig" .Values.webUiBackend.config.mqtt "context" .) | nindent 12 }}
+            # PostgreSQL (always use global config)
+            {{- include "private-assistant.postgres.env" (dict "component" "webUiBackend" "componentConfig" nil "context" .) | nindent 12 }}
+            # MQTT (use global config)
+            {{- include "private-assistant.mqtt.env" (dict "component" "webUiBackend" "componentConfig" nil "context" .) | nindent 12 }}
 
             # MinIO Configuration
             - name: MINIO_ENDPOINT
-              value: {{ .Values.webUiBackend.config.minio.endpoint | quote }}
+              value: {{ .Values.webUi.minio.endpoint | quote }}
             - name: MINIO_BUCKET_NAME
-              value: {{ .Values.webUiBackend.config.minio.bucketName | quote }}
+              value: {{ .Values.webUi.minio.bucketName | quote }}
             - name: MINIO_SECURE
-              value: {{ .Values.webUiBackend.config.minio.secure | quote }}
+              value: {{ .Values.webUi.minio.secure | quote }}
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.webUiBackend.existingSecret }}{{ .Values.webUiBackend.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
+                  name: {{ if .Values.webUi.existingSecret }}{{ .Values.webUi.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
                   key: minio-access-key
             - name: MINIO_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.webUiBackend.existingSecret }}{{ .Values.webUiBackend.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
+                  name: {{ if .Values.webUi.existingSecret }}{{ .Values.webUi.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
                   key: minio-secret-key
 
             # Application Configuration
             - name: ENVIRONMENT
-              value: {{ .Values.webUiBackend.config.app.environment | quote }}
+              value: {{ .Values.webUi.backend.environment | quote }}
             - name: PROJECT_NAME
-              value: {{ .Values.webUiBackend.config.app.projectName | quote }}
+              value: {{ .Values.webUi.backend.projectName | quote }}
+
+            # Auto-generated from ingress
             - name: BACKEND_CORS_ORIGINS
-              value: {{ .Values.webUiBackend.config.app.backendCorsOrigins | quote }}
+              value: {{ include "private-assistant.webui.corsOrigins" . | quote }}
+            - name: FRONTEND_HOST
+              value: {{ include "private-assistant.webui.frontendUrl" . | quote }}
+
+            # Secrets
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.webUiBackend.existingSecret }}{{ .Values.webUiBackend.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
+                  name: {{ if .Values.webUi.existingSecret }}{{ .Values.webUi.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
                   key: secret-key
+
+            # Auto-generated first superuser
             - name: FIRST_SUPERUSER
-              value: {{ .Values.webUiBackend.config.app.firstSuperuser | quote }}
+              value: {{ include "private-assistant.webui.firstSuperuser" . | quote }}
             - name: FIRST_SUPERUSER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.webUiBackend.existingSecret }}{{ .Values.webUiBackend.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
+                  name: {{ if .Values.webUi.existingSecret }}{{ .Values.webUi.existingSecret }}{{ else }}{{ include "private-assistant.fullname" . }}-webui-backend{{ end }}
                   key: first-superuser-password
-            - name: FRONTEND_HOST
-              value: {{ .Values.webUiBackend.config.app.frontendHost | quote }}
+
+            # OAuth Configuration
+            {{- if .Values.webUi.oauth.enabled }}
             - name: DISABLE_OAUTH
-              value: {{ .Values.webUiBackend.config.app.disableOauth | quote }}
-            {{- if .Values.webUiBackend.config.app.oauthIssuer }}
+              value: "false"
             - name: OAUTH_ISSUER
-              value: {{ .Values.webUiBackend.config.app.oauthIssuer | quote }}
-            {{- end }}
-            {{- if .Values.webUiBackend.config.app.oauthClientId }}
+              value: {{ .Values.webUi.oauth.authority | quote }}
             - name: OAUTH_CLIENT_ID
-              value: {{ .Values.webUiBackend.config.app.oauthClientId | quote }}
+              value: {{ .Values.webUi.oauth.clientId | quote }}
+            {{- else }}
+            - name: DISABLE_OAUTH
+              value: "true"
             {{- end }}
+
+            # Component-specific environment overrides
+            {{- with .Values.webUi.backend.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+            # Global environment variables
             {{- with .Values.globalEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- include "private-assistant.deployment.httpProbes" . | nindent 10 }}
           resources:
-            {{- toYaml .Values.webUiBackend.resources | nindent 12 }}
+            {{- toYaml .Values.webUi.backend.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.webUiBackend.securityContext | nindent 12 }}
+            {{- toYaml .Values.webUi.backend.securityContext | nindent 12 }}
 {{- end }}

--- a/charts/private-assistant/templates/webui_backend_ingress.yaml
+++ b/charts/private-assistant/templates/webui_backend_ingress.yaml
@@ -1,3 +1,3 @@
-{{- if and .Values.webUiBackend.enabled .Values.webUiBackend.ingress.enabled -}}
-{{- include "private-assistant.ingress" (dict "component" "webui-backend" "serviceName" "webui-backend" "nameSuffix" "" "config" .Values.webUiBackend.ingress "context" .) }}
+{{- if and .Values.webUi.enabled .Values.webUi.backend.ingress.enabled -}}
+{{- include "private-assistant.ingress" (dict "component" "webui-backend" "serviceName" "webui-backend" "nameSuffix" "" "config" .Values.webUi.backend.ingress "context" .) }}
 {{- end }}

--- a/charts/private-assistant/templates/webui_backend_secret.yaml
+++ b/charts/private-assistant/templates/webui_backend_secret.yaml
@@ -1,16 +1,30 @@
-{{- if and .Values.webUiBackend.enabled (not .Values.webUiBackend.existingSecret) }}
+{{- if and .Values.webUi.enabled (not .Values.webUi.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "private-assistant.fullname" . }}-webui-backend
   labels:
     {{- include "private-assistant.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+    description: "Auto-generated secrets for Web UI. Values persist across upgrades."
 type: Opaque
 data:
-  postgres-password: {{ .Values.webUiBackend.config.postgres.password | default "changethis" | b64enc | quote }}
-  minio-access-key: {{ .Values.webUiBackend.config.minio.accessKey | default "minioadmin" | b64enc | quote }}
-  minio-secret-key: {{ .Values.webUiBackend.config.minio.secretKey | default "minioadmin" | b64enc | quote }}
-  secret-key: {{ .Values.webUiBackend.config.app.secretKey | default "changethis" | b64enc | quote }}
-  first-superuser-password: {{ .Values.webUiBackend.config.app.firstSuperuserPassword | default "changethis" | b64enc | quote }}
-  mqtt-password: {{ .Values.webUiBackend.config.mqtt.password | default "" | b64enc | quote }}
+  # PostgreSQL password from global config
+  {{- if .Values.postgres.existingSecret.enabled }}
+  postgres-password: {{ "placeholder" | b64enc | quote }}
+  {{- else }}
+  postgres-password: {{ .Values.postgres.password | b64enc | quote }}
+  {{- end }}
+
+  # MinIO credentials (defaults for external MinIO)
+  minio-access-key: {{ "minioadmin" | b64enc | quote }}
+  minio-secret-key: {{ "minioadmin" | b64enc | quote }}
+
+  # Auto-generated secrets (persist across upgrades via lookup)
+  secret-key: {{ include "private-assistant.webui.secretKey" . | b64enc | quote }}
+  first-superuser-password: {{ include "private-assistant.webui.firstSuperuserPassword" . | b64enc | quote }}
+
+  # MQTT password
+  mqtt-password: {{ .Values.mosquitto.password | b64enc | quote }}
 {{- end }}

--- a/charts/private-assistant/templates/webui_backend_service.yaml
+++ b/charts/private-assistant/templates/webui_backend_service.yaml
@@ -1,3 +1,3 @@
-{{- if .Values.webUiBackend.enabled }}
-{{- include "private-assistant.service" (dict "component" "webui-backend" "serviceType" .Values.webUiBackend.service.type "context" .) }}
+{{- if .Values.webUi.enabled }}
+{{- include "private-assistant.service" (dict "component" "webui-backend" "serviceType" .Values.webUi.backend.service.type "context" .) }}
 {{- end }}

--- a/charts/private-assistant/templates/webui_frontend_configmap.yaml
+++ b/charts/private-assistant/templates/webui_frontend_configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webUiFrontend.enabled }}
+{{- if .Values.webUi.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/private-assistant/templates/webui_frontend_deployment.yaml
+++ b/charts/private-assistant/templates/webui_frontend_deployment.yaml
@@ -1,16 +1,46 @@
-{{- if .Values.webUiFrontend.enabled }}
+{{- if .Values.webUi.enabled }}
 apiVersion: apps/v1
 kind: Deployment
-{{ include "private-assistant.deployment.metadata" (dict "component" "webui-frontend" "replicas" .Values.webUiFrontend.replicas "hasComponentLabel" true "context" .) }}
-{{ include "private-assistant.deployment.podMetadata" (dict "component" "webui-frontend" "imagePullSecret" .Values.webUiFrontend.image.pullSecret "hasComponentLabel" true "context" .) }}
+{{ include "private-assistant.deployment.metadata" (dict "component" "webui-frontend" "replicas" .Values.webUi.frontend.replicas "hasComponentLabel" true "context" .) }}
+{{ include "private-assistant.deployment.podMetadata" (dict "component" "webui-frontend" "imagePullSecret" .Values.webUi.frontend.image.pullSecret "hasComponentLabel" true "context" .) }}
       containers:
         - name: webui-frontend
-          image: "{{ .Values.webUiFrontend.image.repository }}:{{ .Values.webUiFrontend.image.tag }}"
-          imagePullPolicy: {{ .Values.webUiFrontend.image.pullPolicy }}
+          image: "{{ .Values.webUi.frontend.image.repository }}:{{ .Values.webUi.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.webUi.frontend.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 80
               protocol: TCP
+          env:
+            # Required: Backend API URL (auto-derived from ingress)
+            - name: VITE_API_URL
+              value: {{ include "private-assistant.webui.backendApiUrl" . | quote }}
+
+            # OAuth configuration
+            {{- if .Values.webUi.oauth.enabled }}
+            - name: VITE_OAUTH_AUTHORITY
+              value: {{ .Values.webUi.oauth.authority | quote }}
+            - name: VITE_OAUTH_CLIENT_ID
+              value: {{ .Values.webUi.oauth.clientId | quote }}
+            {{- if .Values.webUi.oauth.redirectUri }}
+            - name: VITE_OAUTH_REDIRECT_URI
+              value: {{ .Values.webUi.oauth.redirectUri | quote }}
+            {{- end }}
+            {{- if .Values.webUi.oauth.scope }}
+            - name: VITE_OAUTH_SCOPE
+              value: {{ .Values.webUi.oauth.scope | quote }}
+            {{- end }}
+            {{- end }}
+
+            # Component-specific environment overrides
+            {{- with .Values.webUi.frontend.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+            # Global environment variables
+            {{- with .Values.globalEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               port: http
@@ -32,9 +62,9 @@ kind: Deployment
             failureThreshold: 30
             periodSeconds: 5
           resources:
-            {{- toYaml .Values.webUiFrontend.resources | nindent 12 }}
+            {{- toYaml .Values.webUi.frontend.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.webUiFrontend.securityContext | nindent 12 }}
+            {{- toYaml .Values.webUi.frontend.securityContext | nindent 12 }}
           volumeMounts:
             - name: nginx-config
               mountPath: /etc/nginx/conf.d

--- a/charts/private-assistant/templates/webui_frontend_ingress.yaml
+++ b/charts/private-assistant/templates/webui_frontend_ingress.yaml
@@ -1,3 +1,3 @@
-{{- if and .Values.webUiFrontend.enabled .Values.webUiFrontend.ingress.enabled -}}
-{{- include "private-assistant.ingress" (dict "component" "webui-frontend" "serviceName" "webui-frontend" "nameSuffix" "" "config" .Values.webUiFrontend.ingress "context" .) }}
+{{- if and .Values.webUi.enabled .Values.webUi.frontend.ingress.enabled -}}
+{{- include "private-assistant.ingress" (dict "component" "webui-frontend" "serviceName" "webui-frontend" "nameSuffix" "" "config" .Values.webUi.frontend.ingress "context" .) }}
 {{- end }}

--- a/charts/private-assistant/templates/webui_frontend_service.yaml
+++ b/charts/private-assistant/templates/webui_frontend_service.yaml
@@ -1,3 +1,3 @@
-{{- if .Values.webUiFrontend.enabled }}
-{{- include "private-assistant.service" (dict "component" "webui-frontend" "serviceType" .Values.webUiFrontend.service.type "context" .) }}
+{{- if .Values.webUi.enabled }}
+{{- include "private-assistant.service" (dict "component" "webui-frontend" "serviceType" .Values.webUi.frontend.service.type "context" .) }}
 {{- end }}

--- a/charts/private-assistant/values.yaml
+++ b/charts/private-assistant/values.yaml
@@ -33,7 +33,8 @@ postgres:
   port: 5432
   db: "private_assistant"
   user: "postgres"
-  password: "changethis"
+  # -- PostgreSQL password (leave empty, provide via existingSecret or external DB)
+  password: ""
 
 # -- TTS (Text-to-Speech) Engine Configuration
 # The TTS engine provides speech synthesis capabilities and uses Valkey (Redis) for caching
@@ -269,8 +270,8 @@ mosquitto:
   servicePort: ""
   # -- MQTT username for authentication (optional)
   username: ""
-  # -- MQTT password for authentication (optional)
-  password: "changethis"
+  # -- MQTT password (leave empty for external broker or if not used)
+  password: ""
 
 # -- Valkey (Redis-compatible) Configuration
 # Valkey is used as a caching layer for the TTS engine
@@ -311,142 +312,119 @@ valkey:
       memory: 256Mi
       cpu: 200m
 
-# -- Web UI Backend Configuration
-# FastAPI backend providing REST API for the web interface
-webUiBackend:
-  # -- Enable/disable the Web UI Backend deployment
+# -- Web UI Configuration
+# Provides a web-based interface for managing the Private Assistant
+webUi:
+  # -- Enable Web UI (both frontend and backend)
   enabled: false
 
-  # Container image configuration
-  image:
-    repository: ghcr.io/stkr22/private-assistant-web-ui-backend
-    tag: "latest"
-    pullPolicy: IfNotPresent
-    pullSecret: ""
-
-  # -- Number of backend replicas
-  replicas: 1
-
-  # -- Resource requests and limits
-  resources: {}
-
-  # Service configuration
-  service:
-    type: ClusterIP
-    port: 8080
-
-  # Ingress configuration for API access
-  ingress:
+  # -- OAuth/OIDC Configuration (shared between frontend and backend)
+  oauth:
+    # -- Enable OAuth authentication
     enabled: false
-    className: "traefik"
-    annotations: {}
-    hosts:
-      - host: api.private-assistant.local
-        paths:
-          - path: /api
-            pathType: Prefix
-    tls: []
+    # -- OAuth authority/issuer URL (e.g., "https://auth.example.com")
+    authority: ""
+    # -- OAuth client ID
+    clientId: ""
+    # -- OAuth redirect URI (optional, auto-derived from frontend ingress if empty)
+    redirectUri: ""
+    # -- OAuth scopes (space-separated)
+    scope: "openid profile email"
 
-  # Security context (follows TTS engine pattern - user 1001:1001)
-  securityContext:
-    capabilities:
-      drop:
-        - ALL
-    runAsUser: 1001
-    runAsGroup: 1001
-    runAsNonRoot: true
-    readOnlyRootFilesystem: false  # FastAPI needs /tmp for uploads, sessions
-    allowPrivilegeEscalation: false
-    privileged: false
-    seccompProfile:
-      type: RuntimeDefault
+  # -- MinIO/S3 Configuration for file storage
+  minio:
+    endpoint: "minio.default.svc.cluster.local:9000"
+    bucketName: "private-assistant"
+    secure: false
+    # Access key and secret key removed - use existingSecret or defaults
 
-  # Backend configuration
-  config:
-    # PostgreSQL configuration (optional - uses global postgres config if not specified)
-    # Leave empty to use global postgres configuration defined at the top level
-    postgres: {}
+  # -- Secrets management
+  existingSecret: ""  # Use existing secret instead of creating one
 
-    # MinIO/S3 configuration (external)
-    minio:
-      endpoint: "minio.default.svc.cluster.local:9000"
-      bucketName: "private-assistant"
-      secure: false
-      # Access key and secret key should be set via existingSecret or will use defaults
+  # -- Frontend Configuration (React + Nginx)
+  frontend:
+    image:
+      repository: ghcr.io/stkr22/private-assistant-web-ui-frontend
+      tag: "latest"
+      pullPolicy: IfNotPresent
+      pullSecret: ""
+    replicas: 1
+    resources: {}
 
-    # MQTT configuration (optional - uses global mosquitto config if not specified)
-    # Leave empty to use global mosquitto configuration defined at the top level
-    mqtt: {}
+    service:
+      type: ClusterIP
+      port: 80
+
+    ingress:
+      enabled: false
+      className: "traefik"
+      annotations: {}
+      hosts:
+        - host: private-assistant.local
+          paths:
+            - path: /
+              pathType: Prefix
+      tls: []
+
+    securityContext:
+      capabilities:
+        drop:
+          - ALL
+      runAsUser: 101
+      runAsGroup: 101
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      privileged: false
+      seccompProfile:
+        type: RuntimeDefault
+
+    # -- Additional environment variables for frontend
+    env: []
+
+  # -- Backend Configuration (FastAPI)
+  backend:
+    image:
+      repository: ghcr.io/stkr22/private-assistant-web-ui-backend
+      tag: "latest"
+      pullPolicy: IfNotPresent
+      pullSecret: ""
+    replicas: 1
+    resources: {}
+
+    service:
+      type: ClusterIP
+      port: 8080
+
+    ingress:
+      enabled: false
+      className: "traefik"
+      annotations: {}
+      hosts:
+        - host: api.private-assistant.local
+          paths:
+            - path: /api
+              pathType: Prefix
+      tls: []
+
+    securityContext:
+      capabilities:
+        drop:
+          - ALL
+      runAsUser: 1001
+      runAsGroup: 1001
+      runAsNonRoot: true
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      privileged: false
+      seccompProfile:
+        type: RuntimeDefault
 
     # Application configuration
-    app:
-      environment: "production"
-      projectName: "Private Assistant"
-      backendCorsOrigins: "http://localhost:3000,http://localhost:5173"
-      firstSuperuser: "admin@example.com"
-      disableOauth: true
-      frontendHost: "http://private-assistant.local"
-      oauthIssuer: ""
-      oauthClientId: ""
-      # secretKey should be set via existingSecret or will use default
-      # firstSuperuserPassword should be set via existingSecret or will use default
+    environment: "production"
+    projectName: "Private Assistant"
+    # firstSuperuser - optional, auto-generated from ingress if empty
+    firstSuperuser: ""
 
-  # -- Existing secret name containing sensitive values
-  # Expected keys:
-  #   - postgres-password
-  #   - minio-access-key
-  #   - minio-secret-key
-  #   - secret-key
-  #   - first-superuser-password
-  #   - mqtt-password
-  existingSecret: ""
-
-# -- Web UI Frontend Configuration
-# React application served by Nginx
-webUiFrontend:
-  # -- Enable/disable the Web UI Frontend deployment
-  enabled: false
-
-  # Container image configuration
-  image:
-    repository: ghcr.io/stkr22/private-assistant-web-ui-frontend
-    tag: "latest"
-    pullPolicy: IfNotPresent
-    pullSecret: ""
-
-  # -- Number of frontend replicas
-  replicas: 1
-
-  # -- Resource requests and limits
-  resources: {}
-
-  # Service configuration
-  service:
-    type: ClusterIP
-    port: 80
-
-  # Ingress configuration for web access
-  ingress:
-    enabled: false
-    className: "traefik"
-    annotations: {}
-    hosts:
-      - host: private-assistant.local
-        paths:
-          - path: /
-            pathType: Prefix
-    tls: []
-
-  # Security context for Nginx
-  securityContext:
-    capabilities:
-      drop:
-        - ALL
-    runAsUser: 101  # Nginx default user
-    runAsGroup: 101
-    runAsNonRoot: true
-    readOnlyRootFilesystem: true
-    allowPrivilegeEscalation: false
-    privileged: false
-    seccompProfile:
-      type: RuntimeDefault
+    # -- Additional environment variables for backend
+    env: []


### PR DESCRIPTION
BREAKING CHANGE: Consolidate webUiBackend and webUiFrontend into unified webUi structure

Major improvements:
- Single webUi.enabled flag controls both frontend and backend
- Auto-generate URLs and CORS origins from ingress configuration
- Auto-generate secrets using lookup + randAlphaNum with persistence
- Shared OAuth configuration between frontend and backend
- Add runtime environment variables for frontend (VITE_*)
- Remove hardcoded password defaults from postgres and mosquitto
- Support component-specific env overrides via env arrays

Migration required:
- webUiBackend.* → webUi.backend.*
- webUiFrontend.* → webUi.frontend.*
- Single webUi.enabled flag replaces separate enable flags